### PR TITLE
Attribute use of Pig Generator code in Pig Character Generator

### DIFF
--- a/src/generators/minecraft-pig-character/MinecraftPigCharacterGenerator.res
+++ b/src/generators/minecraft-pig-character/MinecraftPigCharacterGenerator.res
@@ -9,6 +9,7 @@ let history = [
   "06 Feb 2015 lostminer: Add user variables.",
   "13 Feb 2015 lostminer: Update to use new version of generator.",
   "13 Sep 2020 NinjolasNJM: Updated to use 1.8+ Skins.",
+  "23 Jul 2021 NinjolasNJM: Replaced generator with one derived from Pig Generator by TepigMC.",
 ]
 
 let thumbnail: Generator.thumnbnailDef = {


### PR DESCRIPTION
I noticed that Pig Character Generator is missing attribution to the code it uses from Pig Generator by TepigMC, so I added a note mentioning the changes in commit 28cf5396637ae9d87984459f298ee5ab9c41596e, which was the revision that rewrote it in terms of Pig Generator.